### PR TITLE
Configurable and extensible running of algorithms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ test: install
 	  | $(CLI) new move unmark
 	$(CLI) add-rule-to 'Independent Set' unmarked-and-neighbors-unmarked mark
 	$(CLI) add-rule-to 'Independent Set' marked-and-neighbor-marked unmark
-	$(CLI) run 'Independent Set'
+	$(CLI) run 'Independent Set' 'gn,5:marked=bool' 1000 100 --timeout=20
 # 	the current directory shouldn't matter
-	CURDIR=`pwd` && cd .. && $(PYTHON) $$CURDIR/ssa.py $$CURDIR/temp.ssax run 'Independent Set'
+	CURDIR=`pwd` && cd .. && $(PYTHON) $$CURDIR/ssa.py $$CURDIR/temp.ssax run 'Independent Set' 'gnm,5,7:marked=bool:cool_factor=range,90,99' 3 1
 
 
 check:

--- a/ssa/trial.py
+++ b/ssa/trial.py
@@ -1,0 +1,78 @@
+import networkx as nx
+import random
+from typing import Callable, Dict, List
+import concurrent.futures
+
+import ssa
+
+def apply_properties(graph: nx.Graph, property_generators):
+    for node in graph.nodes:
+        n = graph.node[node]
+        for prop in property_generators:
+            n[prop] = property_generators[prop]()
+    return graph
+
+def get_property_generator(member: str):
+    return globals()['genp_'+member] # GENerate Property
+
+def get_graph_generator_parser(member: str):
+    return globals()['geng_'+member] # GENerate Graph
+
+# define functions that consume the argument piece in the spec
+# and return a function that returns a random graph.
+# (we need this layer of indirection to avoid creating the graph
+# too early).  only required and optional-named parameters are
+# supported (i.e., no keyword arguments).
+def geng_gn(number_of_nodes: str):
+    """Return a graph-generator that gives a graph of a set number of nodes."""
+    return lambda: nx.generators.gn_graph(int(number_of_nodes))
+
+def geng_gnm(number_of_nodes: str, number_of_edges: str):
+    """Return a graph-generator that gives a graph of a set number of nodes and edges."""
+    return lambda: nx.generators.gnm_random_graph(int(number_of_nodes), int(number_of_edges))
+
+def genp_bool() -> Callable[[], bool]:
+    """Random boolean generator."""
+    return lambda: random.random() <= 0.5
+
+def genp_choice(*choices: list):
+    """Random element from choices."""
+    return lambda: random.choice(choices)
+
+def genp_rangef(min: str, max: str) -> Callable[[], float]:
+    """Random real in range [min, max)."""
+    if min == '0' and max == '1':
+        return random.random
+    minf = float(min)
+    return lambda: random.random() * (float(max) - minf) + minf
+
+def genp_range(min: str, max: str) -> Callable[[], int]:
+    """Random integer in range [min, max]."""
+    return lambda: random.randint(int(min), int(max))
+
+def run(algorithm: ssa.Algorithm, graph_generator: Callable[[], nx.Graph], num_iterations: int, num_graphs: int, timeout_seconds: int = 120, workers: int = 32) -> Dict[bool, List[ssa.GraphTimeline]]:
+    """Run an algorithm many, many times in parallel.
+
+    - algorithm: the algorithm to run
+    - graph_generator: a function of no arguments that returns a graph
+    - num_iterations: maximum number of iterations of the algorithm per graph
+    - num_graphs: number of graphs to generate
+
+    - timeout_seconds: after this many seconds, an algorithm will abort
+    - workers: number of workers (threads) to use
+
+    The return value is keyed by whether or not the algorithm
+    stabilized.  The value is a list of run histories.
+
+    """
+    results: Dict[bool, List[ssa.GraphTimeline]] = {True: [], False: []}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = [executor.submit(lambda: algorithm.run(graph_generator(), num_iterations)) \
+                   for i in range(num_graphs)]
+        for f in futures:
+            try:
+                result = f.result(timeout_seconds)
+                results[result[0]].append(result[1])
+            except TimeoutError:
+                print("one of the results timed out!")
+    return results


### PR DESCRIPTION
`run_algorithm()` (and its options) have been enhanced to allow three important configuration options:

- `graph_generator_spec`

  This is a specially-formatted string of three parts:

      generator:arg,arg,...:prop=randomizer,prop=randomizer,...

   `generator` is a predefined graph generator.  New generators are created by defining new functions of a particular naming convention in `trials.py`.  These functions should return functions of no arguments that return an nx.Graph instance.  The functions themselves can take many arguments.

   Each `arg` is passed to the function described by `generator` to produce an *actual* function that creates Graph instances when called.

   Each `prop` is paired with a `randomizer` (also defined in `trials.py` according to a naming convention).  After a random graph is generated by function returned from calling `generator` on the set of arguments provided, that graph instance is run through apply_properties.  This function takes a dictionary of property-names to functions of no arguments (property-value generators).  For every node in each graph instance, the proper generator is called to provide a value for each property.

- `num_graphs`
- `iterations`

  These two options together allow you to create a matrix of algorithm iterations over many, many graphs.  The algorithm will run for `iterations` steps for each of `num_graphs` graphs as generated by the `graph_generator_spec`.

Once this is merged, I'll consider #12 largely addressed.

Fixes #12.