### PR TITLE
Allow moves to read neighbor data

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -6,10 +6,10 @@ import random
 
 # algorithms should be creatable from any callable object,
 # so try just plain ole' functions
-def mark(node):
+def mark(node, _neighbors):
     node['marked'] = True
     return node
-def unmark(node):
+def unmark(node, _neighbors):
     node['marked'] = False
     return node
 def _mark_info(node, neighbors):


### PR DESCRIPTION
This also technicially lets moves write neighbor data, but predicates can already do that.  A guardrail would be nice, but not necessary right now.

Fix #11