### PR TITLE
Store required node attributes in the bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,18 +15,18 @@ test: install
 	$(PYTHON) test/test.py
 	$(CLI) new algorithm 'Independent Set'
 	printf "marked = v['marked'] \nneighbor_marked = any(map(lambda n: n['marked'], N)) \nRESULT = not (marked or neighbor_marked)" \
-	  | $(CLI) new predicate unmarked-and-neighbors-unmarked
+	  | $(CLI) new predicate unmarked-and-neighbors-unmarked -p marked bool
 	printf "marked = v['marked'] \nneighbor_marked = any(map(lambda n: n['marked'], N)) \nRESULT = marked and neighbor_marked" \
-	  | $(CLI) new predicate marked-and-neighbor-marked
+	  | $(CLI) new predicate marked-and-neighbor-marked -p marked bool
 	printf "v['marked'] = True" \
-	  | $(CLI) new move mark
+	  | $(CLI) new move mark -p marked bool
 	printf "v['marked'] = False" \
-	  | $(CLI) new move unmark
+	  | $(CLI) new move unmark -p marked bool
 	$(CLI) add-rule-to 'Independent Set' unmarked-and-neighbors-unmarked mark
 	$(CLI) add-rule-to 'Independent Set' marked-and-neighbor-marked unmark
-	$(CLI) run 'Independent Set' 'gn,5:marked=bool' 1000 100 --timeout=20
+	$(CLI) run 'Independent Set' 'gn,5' 1000 100 --timeout=20
 # 	the current directory shouldn't matter
-	CURDIR=`pwd` && cd .. && $(PYTHON) $$CURDIR/ssa.py $$CURDIR/temp.ssax run 'Independent Set' 'gnm,5,7:marked=bool:cool_factor=range,90,99' 3 1
+	CURDIR=`pwd` && cd .. && $(PYTHON) $$CURDIR/ssa.py $$CURDIR/temp.ssax run 'Independent Set' 'gnm,5,7' 3 1
 
 
 check:

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test: install
 	$(CLI) add-rule-to 'Independent Set' marked-and-neighbor-marked unmark
 	$(CLI) run 'Independent Set' 'gn,5' 1000 100 --timeout=20
 # 	the current directory shouldn't matter
-	CURDIR=`pwd` && cd .. && $(PYTHON) $$CURDIR/ssa.py $$CURDIR/temp.ssax run 'Independent Set' 'gnm,5,7' 3 1
+	CURDIR=`pwd` && cd .. && $(PYTHON) $$CURDIR/ssa.py $$CURDIR/temp.ssax run 'Independent Set' 'gnm,5,7' 3 1 -p age range,1,120
 
 
 check:

--- a/README.org
+++ b/README.org
@@ -103,6 +103,9 @@ command.  The descriptor here (=gn=) determines what mathematical
 properties the generated graph will have (tree/path/cycle/grid/...).
 Note some graph-generators can provide properties of their own.
 
+Property generators defined on predicates/moves can be overridden at
+run-time with the =--property-override= option to =run=.
+
 The definitive list of graph- and property-generators (and their
 arguments) are available in =ssa.trial=.
 

--- a/README.org
+++ b/README.org
@@ -71,11 +71,11 @@ legitimate state after a finite number of moves.
 
 
   # move predefined code to the bundle
-  python3 ssa.py indset.ssax new predicate can-mark < unmarked-and-neighbors-unmarked.py
-  python3 ssa.py indset.ssax new move mark < mark.py
+  python3 ssa.py indset.ssax new predicate can-mark -p marked bool < unmarked-and-neighbors-unmarked.py
+  python3 ssa.py indset.ssax new move      mark     -p marked bool < mark.py
 
-  python3 ssa.py indset.ssax new predicate must-unmark < marked-and-neighbor-marked.py
-  python3 ssa.py indset.ssax new move unmark < unmark.py
+  python3 ssa.py indset.ssax new predicate must-unmark -p marked bool < marked-and-neighbor-marked.py
+  python3 ssa.py indset.ssax new move      unmark      -p marked bool < unmark.py
 
   # create a new algorithm
   python3 ssa.py indset.ssax new algorithm 'Independent Set'
@@ -85,30 +85,24 @@ legitimate state after a finite number of moves.
   python3 ssa.py indset.ssax add-rule-to 'Independent Set' must-unmark unmark
 
   # run the algorithm
-  python3 ssa.py indset.ssax run 'Independent Set' 'gn,5:marked=bool' 1000 100
+  python3 ssa.py indset.ssax run 'Independent Set' gn,5 1000 100
 #+END_SRC
 
 The above =run= command generates 1000 graphs and iterates the algorithm
-100 times on each.  The properties of the graph are determined by the
-special string you see after the algorithm name:
+100 times on each.  The properties of nodes in the graph are
+determined by the predicates and moves composing the rules in the
+algorithm.  For example:
 #+BEGIN_EXAMPLE
-gn,5:marked=bool
+-p age range,1,120...
 #+END_EXAMPLE
-Let's break this down.
-- =gn= :: This is the graph-generation descriptor.  Use this descriptor
-          to generate different graph /structures/ -- how many nodes
-          there are, how many edges, the organization of the graph
-          (tree/path/cycle/grid/...), or different mathematical
-          properties.
-- =5= :: Each comma-delimited piece after the graph-generation
-         descriptor is an argument to the graph-generator.  In the
-         case of =gn=, the only parameter is the number of nodes to
-         create.
-- =marked=bool= :: After the first colon, each colon-separated piece is
-                   a property-generation descriptor of the form
-                   =property_name=generator,args...=.  After a graph is
-                   generated, node properties are added according to
-                   the properties listed here.
+In this example, =range= is called the /generator descriptor/ and =1,120=
+are its arguments.  This particular specification will ensure each
+node has an =age= attribute with a value between =1= and =120=.  The actual
+graph itself is determined by the =gn,5= string you see in the =run=
+command.  The descriptor here (=gn=) determines what mathematical
+properties the generated graph will have (tree/path/cycle/grid/...).
+Note some graph-generators can provide properties of their own.
+
 The definitive list of graph- and property-generators (and their
 arguments) are available in =ssa.trial=.
 

--- a/ssa/bundle.py
+++ b/ssa/bundle.py
@@ -151,8 +151,10 @@ class Bundle(OrderedDict):
         rules = list()
         if 'rules' in alg:
             for rule in alg['rules']:
-                pred = core.Predicate(self._canonicalize_path(rule['predicate']['filename']))
-                move = core.Move(self._canonicalize_path(rule['move']['filename']))
+                for d in [rule['predicate'], rule['move']]:
+                    d['filename'] = self._canonicalize_path(d['filename'])
+                pred = core.Predicate(**rule['predicate'])
+                move = core.Move(**rule['move'])
                 rules.append(core.Rule(pred, move))
         return core.Algorithm(rules)
 

--- a/ssa/cli.py
+++ b/ssa/cli.py
@@ -166,6 +166,12 @@ def run_algorithm(bundle, algorithm_name, graph_generator_spec: str, iterations,
                 elif props[name] != gen:
                     raise Exception(f"Shared node attribute found with conflicting generators: {name} (existing '{props[name]}', new '{gen}')")
 
+    # allow overrides; does not do type-checking yet, but this could
+    # be done with the specified return type of the generator.  This
+    # would probably involve splitting the loop below into two passes.
+    if 'property_override' in kwargs and kwargs['property_override']:
+        props.update({p[0]: p[1] for p in kwargs['property_override']})
+
     # build up the properties dictionary for apply_properties
     properties = dict()
     for prop, genspec in props.items():
@@ -277,6 +283,7 @@ CLIParser = populate_parser(argparse.ArgumentParser(), {
             "$options": {
                "--timeout": { 'type': int },
                "--workers": { 'type': int },
+               ("-p", "--property-override"): PROPSPEC
                 # todo:
                 # --graph-file=graph.gml --format=gml
             },

--- a/ssa/cli.py
+++ b/ssa/cli.py
@@ -227,6 +227,8 @@ def _list_generators_with_prefix(bundle, prefix, **kwargs):
 
 from functools import partial
 
+PROPSPEC = { 'type': str, 'nargs': 2, 'action': 'append', 'metavar': ("name", "type") }
+
 # Now that all our handler functions have been defined, we can define
 # the CLI as an 'options' object for populate_parser.
 CLIParser = populate_parser(argparse.ArgumentParser(), {
@@ -244,14 +246,14 @@ CLIParser = populate_parser(argparse.ArgumentParser(), {
                     "$handler": new_predicate,
                     "$positional": OrderedDict([ ("name", None) ]),
                     "$options": {
-                        ("-p", "--property"): { 'type': str, 'nargs': 2, 'action': 'append', 'metavar': ("name", "type") }
+                        ("-p", "--property"): PROPSPEC
                     }
                 },
                 "move": {
                     "$handler": new_move,
                     "$positional": OrderedDict([ ("name", None) ]),
                     "$options": {
-                        ("-p", "--property"): { 'type': str, 'nargs': 2, 'action': 'append', 'metavar': ("name", "type") }
+                        ("-p", "--property"): PROPSPEC
                     }
                 },
             },
@@ -306,7 +308,8 @@ CLIParser = populate_parser(argparse.ArgumentParser(), {
 def run():
     """Parse and handle command line arguments."""
     import os
-    if "LOG_LEVEL" in os.environ:
-        logging.basicConfig(level=getattr(logging, os.environ["LOG_LEVEL"]))
+    LOG_LEVEL = "LOG_LEVEL"
+    if LOG_LEVEL in os.environ:
+        logging.basicConfig(level=getattr(logging, os.environ[LOG_LEVEL]))
     args = CLIParser.parse_args()
     args.run_handler(**vars(args))

--- a/ssa/cli.py
+++ b/ssa/cli.py
@@ -50,8 +50,9 @@ def populate_parser(parser: argparse.ArgumentParser, options: dict) -> argparse.
             else: parser.add_argument(argument)
     if "$options" in options:
         for argument, argument_config in options["$options"].items():
-            if argument_config: parser.add_argument(argument, **argument_config)
-            else: parser.add_argument(argument, default="")
+            if isinstance(argument, str): argument = (argument,)
+            if argument_config: parser.add_argument(*argument, **argument_config)
+            else: parser.add_argument(*argument, default="")
     if "$subparsers" in options:
         # create a subparser-created
         subparser_creator = parser.add_subparsers(dest=options["$subparsers"]["$destination"])

--- a/ssa/core.py
+++ b/ssa/core.py
@@ -31,6 +31,7 @@ class Executable:
         """
         self.source_file = filename
         self._code = None
+        self._props = kwargs['properties'] if 'properties' in kwargs else None
 
     def _run(self, symbol_table: Dict[str, Any]) -> None:
         """Run the code from `self.source_file` with `params`.

--- a/ssa/core.py
+++ b/ssa/core.py
@@ -22,14 +22,14 @@ class Executable:
     _func: Optional[Callable]
     _code_lines: Optional[List[str]]
 
-    def __init__(self, source_file: str) -> None:
+    def __init__(self, filename: str, **kwargs) -> None:
         """Create a new Executable.
 
         - `source_file`: a canonicalized file containing code
         - `parameters`: a list of parameter names assumable by `source_file`
 
         """
-        self.source_file = source_file
+        self.source_file = filename
         self._code = None
 
     def _run(self, symbol_table: Dict[str, Any]) -> None:


### PR DESCRIPTION
Instead of specifying what attributes to generate every time you run an algorithm, these generators are now stored in the bundle on the components themselves.  This involves an up-front cost of defining the node attributes when creating predicates/moves, but removes that cost and mental burden from the actual *use* of the algorithm.

Fix #18.